### PR TITLE
Add CI/CD github workflow for PRs

### DIFF
--- a/.github/workflows/ci-cd-PR.yml
+++ b/.github/workflows/ci-cd-PR.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: CICD PR
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        make test

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ tox==3.14.0
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0
-Click==7.1.2
+Click==7.0
 pytest==6.2.2


### PR DESCRIPTION
This PR will trigger the building of the package (in python 3.7, 3.8, and 3.9), and running tests in the tests folder when a pull request is made on github using github Actions. 

If tests fail the PR will update with a red cross ❌  above the merge button, and block the merge (even if someone approves the PR). 
If it passes, you'll get a green checkmark ✅  but will still need to wait for approval to merge.