### PR TITLE
Cast project_id to string before concatenating it in KickstarterScraper (fixes a crash under Python 3.7)

### DIFF
--- a/forward43/scraper_kickstarter.py
+++ b/forward43/scraper_kickstarter.py
@@ -32,7 +32,7 @@ class KickstarterScraper(ForwardScraper):
 
         for i in range(num_projects):
             project_list.append({
-                'id'              : self.which_scraper + '_' + data['projects'][i].get('id', 'n.a.'),
+                'id'              : self.which_scraper + '_' + str(data['projects'][i].get('id', 'n.a.')),
                 'title'           : data['projects'][i].get('name', 'n.a.'),
                 'description'     : data['projects'][i].get('blurb', 'n.a.'),
                 'status'          : data['projects'][i].get('state', 'n.a.'),


### PR DESCRIPTION
The KickstarterScraper failed for me under python 3.7.3, due to concatenating a string with an integer. This PR casts that integer (the project id) to a string before concatenating them.

I also had to prefix all imports with the module name (i.e. `from forward43.scraper_kickstarter` instead of just `scraper_kickstarter`, but I'm not sure whether that is just due to my setup. Can create a separate PR for that change if it is useful 🤔