### PR TITLE
Prepend `forward43` to imports within the module

### DIFF
--- a/forward43/es_ingest.py
+++ b/forward43/es_ingest.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-from data.data_path import DATA_DIRECTORY
+from forward43.data.data_path import DATA_DIRECTORY
 
-import utils.elasticsearch as es_utils
+import forward43.utils.elasticsearch as es_utils
 
 
 def load_to_es(filepath, es_object): 

--- a/forward43/es_setup.py
+++ b/forward43/es_setup.py
@@ -1,4 +1,4 @@
-import utils.elasticsearch as es_utils
+import forward43.utils.elasticsearch as es_utils
 
 
 if __name__ == '__main__':

--- a/forward43/scraper.py
+++ b/forward43/scraper.py
@@ -7,8 +7,8 @@ import time
 
 from fp.fp          import FreeProxy
 
-from hparams        import user_agent_list, accept_list
-from data.data_path import DATA_DIRECTORY
+from forward43.hparams        import user_agent_list, accept_list
+from forward43.data.data_path import DATA_DIRECTORY
 
 
 class ForwardScraper:

--- a/forward43/scraper_kickstarter.py
+++ b/forward43/scraper_kickstarter.py
@@ -1,6 +1,6 @@
 import random
 
-from scraper import ForwardScraper
+from forward43.scraper import ForwardScraper
 
 
 class KickstarterScraper(ForwardScraper):

--- a/forward43/scraper_startsomegood.py
+++ b/forward43/scraper_startsomegood.py
@@ -1,6 +1,6 @@
 from bs4     import BeautifulSoup
 
-from scraper import ForwardScraper
+from forward43.scraper import ForwardScraper
 
 
 class StartSomeGoodScraper(ForwardScraper):
@@ -37,7 +37,7 @@ class StartSomeGoodScraper(ForwardScraper):
                 city    = subtitle.contents[2].split(',')[0].strip()
                 country = subtitle.contents[2].split(',')[-1].strip()
                 contact = subtitle.contents[-1].strip()
-            else: 
+            else:
                 city = country = contact = subtitle.text.strip()  # Fallback scenario
 
             project_list.append({

--- a/forward43/scraper_ulule.py
+++ b/forward43/scraper_ulule.py
@@ -1,7 +1,7 @@
 import math
 import requests
 
-from scraper import ForwardScraper
+from forward43.scraper import ForwardScraper
 
 
 class UluleScraper(ForwardScraper):


### PR DESCRIPTION
As @andrewsutjahjo mentioned in the discussion of #15 that he also needed to prefix his imports with the module name for them to work, I've also created this PR that adds this prefixing of the internal module imports.